### PR TITLE
to fix the issues in the parsing of the symbol annotation

### DIFF
--- a/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/DynamicAnalyzer.java
+++ b/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/DynamicAnalyzer.java
@@ -150,7 +150,7 @@ public class DynamicAnalyzer extends Scanner {
 		return properties;
 	}
 	
-	@Symbol("dynamic-analyzer") //$NON-NLS-1$
+	@Symbol("dynamic_analyzer") //$NON-NLS-1$
 	@Extension
 	public static final class DescriptorImpl extends ScanDescriptor {
 		

--- a/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/MobileAnalyzer.java
+++ b/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/MobileAnalyzer.java
@@ -109,7 +109,7 @@ public class MobileAnalyzer extends Scanner {
 		return properties;
 	}
 
-	@Symbol("mobile-analyzer") //$NON-NLS-1$
+	@Symbol("mobile_analyzer") //$NON-NLS-1$
 	@Extension
 	public static final class DescriptorImpl extends ScanDescriptor {
 		

--- a/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/StaticAnalyzer.java
+++ b/src/main/java/com/ibm/appscan/jenkins/plugin/scanners/StaticAnalyzer.java
@@ -27,7 +27,7 @@ public class StaticAnalyzer extends Scanner {
 		return STATIC_ANALYZER;
 	}
 	
-	@Symbol("static-analyzer") //$NON-NLS-1$
+	@Symbol("static_analyzer") //$NON-NLS-1$
 	@Extension
 	public static final class DescriptorImpl extends ScanDescriptor {
 		


### PR DESCRIPTION
pipeline build was failing with the current code as it was treating the scanner type as unknown .
I tried to use underscore in place of hyphen in the symbol annotation for scanner type and it worked .

Looks like the hyphen is not supported for the symbol name but I am not sure about this as I didn't find any doc or article or blog confirming the same .
Will raise a bug with jenkins ,if required .