### PR TITLE
description of build and latest report of failed build

### DIFF
--- a/src/main/java/com/ibm/appscan/jenkins/plugin/actions/ScanResultsTrend.java
+++ b/src/main/java/com/ibm/appscan/jenkins/plugin/actions/ScanResultsTrend.java
@@ -126,7 +126,7 @@ public class ScanResultsTrend extends AppScanAction {
 	private ScanResults getLatestResults() {
 		for(Run<?,?> run : m_project.getBuilds()) {
 			for(ScanResults results : run.getActions(ScanResults.class)) {
-				if(results.getScanType().equalsIgnoreCase(m_type) && results.getName().equalsIgnoreCase(m_name) && results.getHasResults()) {
+				if(results.getScanType().equalsIgnoreCase(m_type) && results.getName().equalsIgnoreCase(m_name)) {
 					return results;
 				}
 			}

--- a/src/main/java/com/ibm/appscan/jenkins/plugin/builders/AppScanBuildStep.java
+++ b/src/main/java/com/ibm/appscan/jenkins/plugin/builders/AppScanBuildStep.java
@@ -240,20 +240,23 @@ public class AppScanBuildStep extends Builder implements SimpleBuildStep, Serial
     }
     
     
-    private void shouldFailBuild(IResultsProvider provider) throws AbortException{
+    private void shouldFailBuild(IResultsProvider provider,Run<?,?> build) throws AbortException, IOException{
     	if(!m_failBuild && !m_failBuildNonCompliance)
     		return ;
         String failureMessage=Messages.error_threshold_exceeded();
 		try {
                     List<FailureCondition> failureConditions=m_failureConditions;
                     if (m_failBuildNonCompliance){
-                        failureConditions =new ArrayList<FailureCondition>();
+                        failureConditions =new ArrayList<>();
                         FailureCondition nonCompliantCondition = new FailureCondition("total", 0);
                         failureConditions.add(nonCompliantCondition);
                         failureMessage=Messages.error_noncompliant_issues();
                     }
-	    	if(new ResultsInspector(failureConditions, provider).shouldFail())
+	    	if(new ResultsInspector(failureConditions, provider).shouldFail()){
+                    build.setDescription(failureMessage);
                     throw new AbortException(failureMessage);
+                }
+                    
 	    } catch(NullPointerException e) {
 	    	throw new AbortException(Messages.error_checking_results(provider.getStatus()));
 	    }
@@ -303,7 +306,7 @@ public class AppScanBuildStep extends Builder implements SimpleBuildStep, Serial
     	build.addAction(new ResultsRetriever(build, provider, m_name));
                 
         if(m_wait)
-            shouldFailBuild(provider);	
+            shouldFailBuild(provider,build);	
     }
     
     private void setInstallDir() {


### PR DESCRIPTION
It fixes 2 things
1. set the description of the build in case of any failure so that user can see the reason of failure of builds from the project page
2. the latest report link on the project page will show the report of latest build (even if it is in failed state) .However it will work only if there is atleast one successful build associated with the project